### PR TITLE
[v2] Botocore request checksum calculation

### DIFF
--- a/awscli/botocore/config.py
+++ b/awscli/botocore/config.py
@@ -194,6 +194,37 @@ class Config(object):
     :param sigv4a_signing_region_set: A set of AWS regions to apply the signature for
         when using SigV4a for signing. Set to ``*`` to represent all regions.
         Defaults to None.
+
+    :type request_checksum_calculation: str
+    :param request_checksum_calculation: Determines when a checksum will be
+        calculated for request payloads. Valid values are:
+
+        * ``when_supported`` -- When set, a checksum will be calculated for
+            all request payloads of operations modeled with the ``httpChecksum``
+            trait where ``requestChecksumRequired`` is ``true`` and/or a
+            ``requestAlgorithmMember`` is modeled.
+
+        * ``when_required`` -- When set, a checksum will only be calculated
+            for request payloads of operations modeled with the ``httpChecksum``
+            trait where ``requestChecksumRequired`` is ``true`` or where a
+            ``requestAlgorithmMember`` is modeled and supplied.
+
+        Defaults to None.
+
+    :type response_checksum_validation: str
+    :param response_checksum_validation: Determines when checksum validation
+        will be performed on response payloads. Valid values are:
+
+        * ``when_supported`` -- When set, checksum validation is performed on
+            all response payloads of operations modeled with the ``httpChecksum``
+            trait where ``responseAlgorithms`` is modeled, except when no modeled
+            checksum algorithms are supported.
+
+        * ``when_required`` -- When set, checksum validation is not performed
+            on response payloads of operations unless the checksum algorithm is
+            supported and the ``requestValidationModeMember`` member is set to ``ENABLED``.
+
+        Defaults to None.
     """
     OPTION_DEFAULTS = OrderedDict([
         ('region_name', None),
@@ -218,6 +249,8 @@ class Config(object):
         ('request_min_compression_size_bytes', None),
         ('disable_request_compression', None),
         ('sigv4a_signing_region_set', None),
+        ('request_checksum_calculation', None),
+        ('response_checksum_validation', None),
     ])
 
     def __init__(self, *args, **kwargs):

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -137,6 +137,18 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         None,
         None,
     ),
+    'request_checksum_calculation': (
+        'request_checksum_calculation',
+        'AWS_REQUEST_CHECKSUM_CALCULATION',
+        "when_supported",
+        None,
+    ),
+    'response_checksum_validation': (
+        'response_checksum_validation',
+        'AWS_RESPONSE_CHECKSUM_VALIDATION',
+        "when_supported",
+        None,
+    ),
 }
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping
@@ -336,7 +348,7 @@ class ConfigValueStore(object):
 
     def get_config_variable(self, logical_name):
         """
-        Retrieve the value associeated with the specified logical_name
+        Retrieve the value associated with the specified logical_name
         from the corresponding provider. If no value is found None will
         be returned.
 

--- a/awscli/botocore/exceptions.py
+++ b/awscli/botocore/exceptions.py
@@ -742,3 +742,12 @@ class EndpointResolutionError(EndpointProviderError):
 
 class UnknownEndpointResolutionBuiltInName(EndpointProviderError):
     fmt = 'Unknown builtin variable name: {name}'
+
+
+class InvalidChecksumConfigError(BotoCoreError):
+    """Error when invalid value supplied for checksum config"""
+
+    fmt = (
+        'Unsupported configuration value for {config_key}. '
+        'Expected one of {valid_options} but got {config_value}.'
+    )

--- a/awscli/botocore/httpchecksum.py
+++ b/awscli/botocore/httpchecksum.py
@@ -25,7 +25,7 @@ from binascii import crc32
 from hashlib import sha1, sha256
 
 from awscrt import checksums as crt_checksums
-from botocore.compat import HAS_CRT, urlparse
+from botocore.compat import urlparse
 from botocore.exceptions import AwsChunkedWrapperError, FlexibleChecksumError
 from botocore.response import StreamingBody
 from botocore.utils import determine_content_length, has_checksum_header

--- a/awscli/botocore/httpchecksum.py
+++ b/awscli/botocore/httpchecksum.py
@@ -25,14 +25,14 @@ from binascii import crc32
 from hashlib import sha1, sha256
 
 from awscrt import checksums as crt_checksums
+from botocore.compat import HAS_CRT, urlparse
 from botocore.exceptions import AwsChunkedWrapperError, FlexibleChecksumError
 from botocore.response import StreamingBody
-from botocore.utils import (
-    conditionally_calculate_md5,
-    determine_content_length,
-)
+from botocore.utils import determine_content_length, has_checksum_header
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CHECKSUM_ALGORITHM = "CRC32"
 
 
 class BaseChecksum:
@@ -246,7 +246,18 @@ def resolve_checksum_context(request, operation_model, params):
 def resolve_request_checksum_algorithm(
     request, operation_model, params, supported_algorithms=None,
 ):
+    # If the header is already set by the customer, skip calculation
+    if has_checksum_header(request):
+        return
+
+    request_checksum_calculation = request["context"][
+        "client_config"
+    ].request_checksum_calculation
     http_checksum = operation_model.http_checksum
+    request_checksum_required = (
+            operation_model.http_checksum_required
+            or http_checksum.get("requestChecksumRequired")
+    )
     algorithm_member = http_checksum.get("requestAlgorithmMember")
     if algorithm_member and algorithm_member in params:
         # If the client has opted into using flexible checksums and the
@@ -259,35 +270,32 @@ def resolve_request_checksum_algorithm(
             raise FlexibleChecksumError(
                 error_msg="Unsupported checksum algorithm: %s" % algorithm_name
             )
-
-        location_type = "header"
-        if operation_model.has_streaming_input:
-            # Operations with streaming input must support trailers.
-            if request["url"].startswith("https:"):
-                # We only support unsigned trailer checksums currently. As this
-                # disables payload signing we'll only use trailers over TLS.
-                location_type = "trailer"
-
-        algorithm = {
-            "algorithm": algorithm_name,
-            "in": location_type,
-            "name": "x-amz-checksum-%s" % algorithm_name,
-        }
-
-        if algorithm["name"] in request["headers"]:
-            # If the header is already set by the customer, skip calculation
-            return
-
-        checksum_context = request["context"].get("checksum", {})
-        checksum_context["request_algorithm"] = algorithm
-        request["context"]["checksum"] = checksum_context
-    elif operation_model.http_checksum_required or http_checksum.get(
-        "requestChecksumRequired"
+    elif request_checksum_required or (
+            algorithm_member and request_checksum_calculation == "when_supported"
     ):
-        # Otherwise apply the old http checksum behavior via Content-MD5
-        checksum_context = request["context"].get("checksum", {})
-        checksum_context["request_algorithm"] = "conditional-md5"
-        request["context"]["checksum"] = checksum_context
+        algorithm_name = DEFAULT_CHECKSUM_ALGORITHM.lower()
+    else:
+        return
+
+    location_type = "header"
+    if (
+            operation_model.has_streaming_input
+            and urlparse(request["url"]).scheme == "https"
+    ):
+        # Operations with streaming input must support trailers.
+        # We only support unsigned trailer checksums currently. As this
+        # disables payload signing we'll only use trailers over TLS.
+        location_type = "trailer"
+
+    algorithm = {
+        "algorithm": algorithm_name,
+        "in": location_type,
+        "name": f"x-amz-checksum-{algorithm_name}",
+    }
+
+    checksum_context = request["context"].get("checksum", {})
+    checksum_context["request_algorithm"] = algorithm
+    request["context"]["checksum"] = checksum_context
 
 
 def apply_request_checksum(request):
@@ -297,10 +305,7 @@ def apply_request_checksum(request):
     if not algorithm:
         return
 
-    if algorithm == "conditional-md5":
-        # Special case to handle the http checksum required trait
-        conditionally_calculate_md5(request)
-    elif algorithm["in"] == "header":
+    if algorithm["in"] == "header":
         _apply_request_header_checksum(request)
     elif algorithm["in"] == "trailer":
         _apply_request_trailer_checksum(request)

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -2996,6 +2996,7 @@ def _is_s3express_request(params):
 def has_checksum_header(params):
     """
     Checks if a header starting with "x-amz-checksum-" is provided in a request.
+
     This class is considered private and subject to abrupt breaking changes or
     removal without prior announcement. Please do not use it directly.
     """
@@ -3038,6 +3039,7 @@ def conditionally_enable_crc32(params, **kwargs):
 def conditionally_calculate_md5(params, **kwargs):
     """
     This function has been deprecated, but is kept for backwards compatibility.
+
     Only add a Content-MD5 if the system supports it.
     """
     body = params['body']

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -2962,6 +2962,7 @@ def get_encoding_from_headers(headers, default='ISO-8859-1'):
 
 
 def calculate_md5(body, **kwargs):
+    """This function has been deprecated, but is kept for backwards compatibility."""
     if isinstance(body, (bytes, bytearray)):
         binary_md5 = _calculate_md5_from_bytes(body)
     else:
@@ -2970,11 +2971,13 @@ def calculate_md5(body, **kwargs):
 
 
 def _calculate_md5_from_bytes(body_bytes):
+    """This function has been deprecated, but is kept for backwards compatibility."""
     md5 = get_md5(body_bytes)
     return md5.digest()
 
 
 def _calculate_md5_from_file(fileobj):
+    """This function has been deprecated, but is kept for backwards compatibility."""
     start_position = fileobj.tell()
     md5 = get_md5()
     for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
@@ -2990,15 +2993,16 @@ def _is_s3express_request(params):
     return endpoint_properties.get('backend') == 'S3Express'
 
 
-def _has_checksum_header(params):
+def has_checksum_header(params):
+    """
+    Checks if a header starting with "x-amz-checksum-" is provided in a request.
+    This class is considered private and subject to abrupt breaking changes or
+    removal without prior announcement. Please do not use it directly.
+    """
     headers = params['headers']
-    # If a user provided Content-MD5 is present,
-    # don't try to compute a new one.
-    if 'Content-MD5' in headers:
-        return True
 
     # If a header matching the x-amz-checksum-* pattern is present, we
-    # assume a checksum has already been provided and an md5 is not needed
+    # assume a checksum has already been provided by the user.
     for header in headers:
         if CHECKSUM_HEADER_PATTERN.match(header):
             return True
@@ -3007,12 +3011,14 @@ def _has_checksum_header(params):
 
 
 def conditionally_calculate_checksum(params, **kwargs):
-    if not _has_checksum_header(params):
+    """This function has been deprecated, but is kept for backwards compatibility."""
+    if not has_checksum_header(params):
         conditionally_calculate_md5(params, **kwargs)
         conditionally_enable_crc32(params, **kwargs)
 
 
 def conditionally_enable_crc32(params, **kwargs):
+    """This function has been deprecated, but is kept for backwards compatibility."""
     checksum_context = params.get('context', {}).get('checksum', {})
     checksum_algorithm = checksum_context.get('request_algorithm')
     if (
@@ -3030,7 +3036,10 @@ def conditionally_enable_crc32(params, **kwargs):
 
 
 def conditionally_calculate_md5(params, **kwargs):
-    """Only add a Content-MD5 if the system supports it."""
+    """
+    This function has been deprecated, but is kept for backwards compatibility.
+    Only add a Content-MD5 if the system supports it.
+    """
     body = params['body']
     checksum_context = params.get('context', {}).get('checksum', {})
     checksum_algorithm = checksum_context.get('request_algorithm')
@@ -3038,7 +3047,7 @@ def conditionally_calculate_md5(params, **kwargs):
         # Skip for requests that will have a flexible checksum applied
         return
 
-    if _has_checksum_header(params):
+    if has_checksum_header(params):
         # Don't add a new header if one is already available.
         return
 

--- a/tests/functional/botocore/test_httpchecksum.py
+++ b/tests/functional/botocore/test_httpchecksum.py
@@ -14,7 +14,6 @@
 
 import pytest
 
-from botocore.compat import HAS_CRT
 from botocore.exceptions import FlexibleChecksumError
 from tests import ClientHTTPStubber, patch_load_service_model
 
@@ -151,7 +150,7 @@ TEST_CHECKSUM_RULESET = {
 
 def _request_checksum_calculation_cases():
     request_payload = "Hello world"
-    cases = [
+    return [
         (
             "CRC32",
             request_payload,
@@ -176,29 +175,23 @@ def _request_checksum_calculation_cases():
                 "x-amz-checksum-sha256": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw=",
             },
         ),
+        (
+            "CRC32C",
+            request_payload,
+            {
+                "x-amz-request-algorithm": "CRC32C",
+                "x-amz-checksum-crc32c": "crUfeA==",
+            },
+        ),
+        (
+            "CRC64NVME",
+            request_payload,
+            {
+                "x-amz-request-algorithm": "CRC64NVME",
+                "x-amz-checksum-crc64nvme": "OOJZ0D8xKts=",
+            },
+        ),
     ]
-    if HAS_CRT:
-        cases.extend(
-            [
-                (
-                    "CRC32C",
-                    request_payload,
-                    {
-                        "x-amz-request-algorithm": "CRC32C",
-                        "x-amz-checksum-crc32c": "crUfeA==",
-                    },
-                ),
-                (
-                    "CRC64NVME",
-                    request_payload,
-                    {
-                        "x-amz-request-algorithm": "CRC64NVME",
-                        "x-amz-checksum-crc64nvme": "OOJZ0D8xKts=",
-                    },
-                ),
-            ]
-        )
-    return cases
 
 
 @pytest.mark.parametrize(
@@ -235,7 +228,7 @@ def test_request_checksum_calculation(
 
 def _streaming_request_checksum_calculation_cases():
     request_payload = "Hello world"
-    cases = [
+    return [
         (
             "CRC32",
             request_payload,
@@ -265,31 +258,25 @@ def _streaming_request_checksum_calculation_cases():
                 "x-amz-checksum-sha256": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw="
             },
         ),
+        (
+            "CRC32C",
+            request_payload,
+            {
+                "content-encoding": "aws-chunked",
+                "x-amz-trailer": "x-amz-checksum-crc32c",
+            },
+            {"x-amz-checksum-crc32c": "crUfeA=="},
+        ),
+        (
+            "CRC64NVME",
+            request_payload,
+            {
+                "content-encoding": "aws-chunked",
+                "x-amz-trailer": "x-amz-checksum-crc64nvme",
+            },
+            {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
+        ),
     ]
-    if HAS_CRT:
-        cases.extend(
-            [
-                (
-                    "CRC32C",
-                    request_payload,
-                    {
-                        "content-encoding": "aws-chunked",
-                        "x-amz-trailer": "x-amz-checksum-crc32c",
-                    },
-                    {"x-amz-checksum-crc32c": "crUfeA=="},
-                ),
-                (
-                    "CRC64NVME",
-                    request_payload,
-                    {
-                        "content-encoding": "aws-chunked",
-                        "x-amz-trailer": "x-amz-checksum-crc64nvme",
-                    },
-                    {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
-                ),
-            ]
-        )
-    return cases
 
 
 @pytest.mark.parametrize(
@@ -331,7 +318,7 @@ def test_streaming_request_checksum_calculation(
 
 def _response_checksum_validation_cases():
     response_payload = "Hello world"
-    cases = [
+    return [
         (
             "CRC32",
             response_payload,
@@ -376,37 +363,31 @@ def _response_checksum_validation_cases():
                 "calculatedChecksum": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw=",
             },
         ),
+        (
+            "CRC32C",
+            response_payload,
+            {"x-amz-checksum-crc32c": "crUfeA=="},
+            {"kind": "success"},
+        ),
+        (
+            "CRC32C",
+            response_payload,
+            {"x-amz-checksum-crc32c": "bm90LWEtY2hlY2tzdW0="},
+            {"kind": "failure", "calculatedChecksum": "crUfeA=="},
+        ),
+        (
+            "CRC64NVME",
+            response_payload,
+            {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
+            {"kind": "success"},
+        ),
+        (
+            "CRC64NVME",
+            response_payload,
+            {"x-amz-checksum-crc64nvme": "bm90LWEtY2hlY2tzdW0="},
+            {"kind": "failure", "calculatedChecksum": "OOJZ0D8xKts="},
+        ),
     ]
-    if HAS_CRT:
-        cases.extend(
-            [
-                (
-                    "CRC32C",
-                    response_payload,
-                    {"x-amz-checksum-crc32c": "crUfeA=="},
-                    {"kind": "success"},
-                ),
-                (
-                    "CRC32C",
-                    response_payload,
-                    {"x-amz-checksum-crc32c": "bm90LWEtY2hlY2tzdW0="},
-                    {"kind": "failure", "calculatedChecksum": "crUfeA=="},
-                ),
-                (
-                    "CRC64NVME",
-                    response_payload,
-                    {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
-                    {"kind": "success"},
-                ),
-                (
-                    "CRC64NVME",
-                    response_payload,
-                    {"x-amz-checksum-crc64nvme": "bm90LWEtY2hlY2tzdW0="},
-                    {"kind": "failure", "calculatedChecksum": "OOJZ0D8xKts="},
-                ),
-            ]
-        )
-    return cases
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/botocore/test_httpchecksum.py
+++ b/tests/functional/botocore/test_httpchecksum.py
@@ -1,0 +1,501 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+import pytest
+
+from botocore.compat import HAS_CRT
+from botocore.exceptions import FlexibleChecksumError
+from tests import ClientHTTPStubber, patch_load_service_model
+
+TEST_CHECKSUM_SERVICE_MODEL = {
+    "version": "2.0",
+    "documentation": "This is a test service.",
+    "metadata": {
+        "apiVersion": "2023-01-01",
+        "endpointPrefix": "test",
+        "protocol": "rest-json",
+        "jsonVersion": "1.1",
+        "serviceFullName": "Test Service",
+        "serviceId": "Test Service",
+        "signatureVersion": "v4",
+        "signingName": "testservice",
+        "uid": "testservice-2023-01-01",
+    },
+    "operations": {
+        "HttpChecksumOperation": {
+            "name": "HttpChecksumOperation",
+            "http": {"method": "POST", "requestUri": "/HttpChecksumOperation"},
+            "input": {"shape": "SomeInput"},
+            "output": {"shape": "SomeOutput"},
+            "httpChecksum": {
+                "requestChecksumRequired": True,
+                "requestAlgorithmMember": "checksumAlgorithm",
+                "requestValidationModeMember": "validationMode",
+                "responseAlgorithms": [
+                    "CRC32",
+                    "CRC32C",
+                    "CRC64NVME",
+                    "SHA1",
+                    "SHA256",
+                ],
+            },
+        },
+        "HttpChecksumStreamingOperation": {
+            "name": "HttpChecksumStreamingOperation",
+            "http": {
+                "method": "POST",
+                "requestUri": "/HttpChecksumStreamingOperation",
+            },
+            "input": {"shape": "SomeStreamingInput"},
+            "output": {"shape": "SomeStreamingOutput"},
+            "httpChecksum": {
+                "requestChecksumRequired": True,
+                "requestAlgorithmMember": "checksumAlgorithm",
+                "requestValidationModeMember": "validationMode",
+                "responseAlgorithms": [
+                    "CRC32",
+                    "CRC32C",
+                    "CRC64NVME",
+                    "SHA1",
+                    "SHA256",
+                ],
+            },
+        },
+    },
+    "shapes": {
+        "ChecksumAlgorithm": {
+            "type": "string",
+            "enum": {"CRC32", "CRC32C", "CRC64NVME", "SHA1", "SHA256"},
+            "member": {"shape": "MockOpParam"},
+        },
+        "ValidationMode": {"type": "string", "enum": {"ENABLE"}},
+        "String": {"type": "string"},
+        "Blob": {"type": "blob"},
+        "SomeStreamingOutput": {
+            "type": "structure",
+            "members": {"body": {"shape": "Blob", "streaming": True}},
+            "payload": "body",
+        },
+        "SomeStreamingInput": {
+            "type": "structure",
+            "required": ["body"],
+            "members": {
+                "body": {
+                    "shape": "Blob",
+                    "streaming": True,
+                },
+                "validationMode": {
+                    "shape": "ValidationMode",
+                    "location": "header",
+                    "locationName": "x-amz-response-validation-mode",
+                },
+                "checksumAlgorithm": {
+                    "shape": "ChecksumAlgorithm",
+                    "location": "header",
+                    "locationName": "x-amz-request-algorithm",
+                },
+            },
+            "payload": "body",
+        },
+        "SomeInput": {
+            "type": "structure",
+            "required": ["body"],
+            "members": {
+                "body": {"shape": "String"},
+                "validationMode": {
+                    "shape": "ValidationMode",
+                    "location": "header",
+                    "locationName": "x-amz-response-validation-mode",
+                },
+                "checksumAlgorithm": {
+                    "shape": "ChecksumAlgorithm",
+                    "location": "header",
+                    "locationName": "x-amz-request-algorithm",
+                },
+            },
+            "payload": "body",
+        },
+        "SomeOutput": {
+            "type": "structure",
+        },
+    },
+}
+
+TEST_CHECKSUM_RULESET = {
+    "version": "1.0",
+    "parameters": {},
+    "rules": [
+        {
+            "conditions": [],
+            "type": "endpoint",
+            "endpoint": {
+                "url": "https://foo.bar",
+                "properties": {},
+                "headers": {},
+            },
+        }
+    ],
+}
+
+
+def _request_checksum_calculation_cases():
+    request_payload = "Hello world"
+    cases = [
+        (
+            "CRC32",
+            request_payload,
+            {
+                "x-amz-request-algorithm": "CRC32",
+                "x-amz-checksum-crc32": "i9aeUg==",
+            },
+        ),
+        (
+            "SHA1",
+            request_payload,
+            {
+                "x-amz-request-algorithm": "SHA1",
+                "x-amz-checksum-sha1": "e1AsOh9IyGCa4hLN+2Od7jlnP14=",
+            },
+        ),
+        (
+            "SHA256",
+            request_payload,
+            {
+                "x-amz-request-algorithm": "SHA256",
+                "x-amz-checksum-sha256": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw=",
+            },
+        ),
+    ]
+    if HAS_CRT:
+        cases.extend(
+            [
+                (
+                    "CRC32C",
+                    request_payload,
+                    {
+                        "x-amz-request-algorithm": "CRC32C",
+                        "x-amz-checksum-crc32c": "crUfeA==",
+                    },
+                ),
+                (
+                    "CRC64NVME",
+                    request_payload,
+                    {
+                        "x-amz-request-algorithm": "CRC64NVME",
+                        "x-amz-checksum-crc64nvme": "OOJZ0D8xKts=",
+                    },
+                ),
+            ]
+        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    "checksum_algorithm, request_payload, expected_headers",
+    _request_checksum_calculation_cases(),
+)
+def test_request_checksum_calculation(
+    patched_session,
+    monkeypatch,
+    checksum_algorithm,
+    request_payload,
+    expected_headers,
+):
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        TEST_CHECKSUM_SERVICE_MODEL,
+        TEST_CHECKSUM_RULESET,
+    )
+    client = patched_session.create_client(
+        "testservice",
+        region_name="us-west-2",
+    )
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(status=200, body=b"<response/>")
+        client.http_checksum_operation(
+            body=request_payload, checksumAlgorithm=checksum_algorithm
+        )
+        actual_headers = http_stubber.requests[0].headers
+        for key, val in expected_headers.items():
+            assert key in actual_headers
+            assert actual_headers[key].decode() == val
+
+
+def _streaming_request_checksum_calculation_cases():
+    request_payload = "Hello world"
+    cases = [
+        (
+            "CRC32",
+            request_payload,
+            {
+                "content-encoding": "aws-chunked",
+                "x-amz-trailer": "x-amz-checksum-crc32",
+            },
+            {"x-amz-checksum-crc32": "i9aeUg=="},
+        ),
+        (
+            "SHA1",
+            request_payload,
+            {
+                "content-encoding": "aws-chunked",
+                "x-amz-trailer": "x-amz-checksum-sha1",
+            },
+            {"x-amz-checksum-sha1": "e1AsOh9IyGCa4hLN+2Od7jlnP14="},
+        ),
+        (
+            "SHA256",
+            request_payload,
+            {
+                "content-encoding": "aws-chunked",
+                "x-amz-trailer": "x-amz-checksum-sha256",
+            },
+            {
+                "x-amz-checksum-sha256": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw="
+            },
+        ),
+    ]
+    if HAS_CRT:
+        cases.extend(
+            [
+                (
+                    "CRC32C",
+                    request_payload,
+                    {
+                        "content-encoding": "aws-chunked",
+                        "x-amz-trailer": "x-amz-checksum-crc32c",
+                    },
+                    {"x-amz-checksum-crc32c": "crUfeA=="},
+                ),
+                (
+                    "CRC64NVME",
+                    request_payload,
+                    {
+                        "content-encoding": "aws-chunked",
+                        "x-amz-trailer": "x-amz-checksum-crc64nvme",
+                    },
+                    {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
+                ),
+            ]
+        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    "checksum_algorithm, request_payload, expected_headers, expected_trailers",
+    _streaming_request_checksum_calculation_cases(),
+)
+def test_streaming_request_checksum_calculation(
+    patched_session,
+    monkeypatch,
+    checksum_algorithm,
+    request_payload,
+    expected_headers,
+    expected_trailers,
+):
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        TEST_CHECKSUM_SERVICE_MODEL,
+        TEST_CHECKSUM_RULESET,
+    )
+    client = patched_session.create_client(
+        "testservice",
+        region_name="us-west-2",
+    )
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(status=200, body=b"<response/>")
+        client.http_checksum_streaming_operation(
+            body=request_payload, checksumAlgorithm=checksum_algorithm
+        )
+        request = http_stubber.requests[0]
+        actual_headers = request.headers
+        for key, val in expected_headers.items():
+            assert key in actual_headers
+            assert actual_headers[key].decode() == val
+        read_body = request.body.read()
+        for key, val in expected_trailers.items():
+            assert f"{key}:{val}".encode() in read_body
+
+
+def _response_checksum_validation_cases():
+    response_payload = "Hello world"
+    cases = [
+        (
+            "CRC32",
+            response_payload,
+            {"x-amz-checksum-crc32": "i9aeUg=="},
+            {"kind": "success"},
+        ),
+        (
+            "CRC32",
+            response_payload,
+            {"x-amz-checksum-crc32": "bm90LWEtY2hlY2tzdW0="},
+            {"kind": "failure", "calculatedChecksum": "i9aeUg=="},
+        ),
+        (
+            "SHA1",
+            response_payload,
+            {"x-amz-checksum-sha1": "e1AsOh9IyGCa4hLN+2Od7jlnP14="},
+            {"kind": "success"},
+        ),
+        (
+            "SHA1",
+            response_payload,
+            {"x-amz-checksum-sha1": "bm90LWEtY2hlY2tzdW0="},
+            {
+                "kind": "failure",
+                "calculatedChecksum": "e1AsOh9IyGCa4hLN+2Od7jlnP14=",
+            },
+        ),
+        (
+            "SHA256",
+            response_payload,
+            {
+                "x-amz-checksum-sha256": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw="
+            },
+            {"kind": "success"},
+        ),
+        (
+            "SHA256",
+            response_payload,
+            {"x-amz-checksum-sha256": "bm90LWEtY2hlY2tzdW0="},
+            {
+                "kind": "failure",
+                "calculatedChecksum": "ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw=",
+            },
+        ),
+    ]
+    if HAS_CRT:
+        cases.extend(
+            [
+                (
+                    "CRC32C",
+                    response_payload,
+                    {"x-amz-checksum-crc32c": "crUfeA=="},
+                    {"kind": "success"},
+                ),
+                (
+                    "CRC32C",
+                    response_payload,
+                    {"x-amz-checksum-crc32c": "bm90LWEtY2hlY2tzdW0="},
+                    {"kind": "failure", "calculatedChecksum": "crUfeA=="},
+                ),
+                (
+                    "CRC64NVME",
+                    response_payload,
+                    {"x-amz-checksum-crc64nvme": "OOJZ0D8xKts="},
+                    {"kind": "success"},
+                ),
+                (
+                    "CRC64NVME",
+                    response_payload,
+                    {"x-amz-checksum-crc64nvme": "bm90LWEtY2hlY2tzdW0="},
+                    {"kind": "failure", "calculatedChecksum": "OOJZ0D8xKts="},
+                ),
+            ]
+        )
+    return cases
+
+
+@pytest.mark.parametrize(
+    "checksum_algorithm, response_payload, response_headers, expected",
+    _response_checksum_validation_cases(),
+)
+def test_response_checksum_validation(
+    patched_session,
+    monkeypatch,
+    checksum_algorithm,
+    response_payload,
+    response_headers,
+    expected,
+):
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        TEST_CHECKSUM_SERVICE_MODEL,
+        TEST_CHECKSUM_RULESET,
+    )
+    client = patched_session.create_client(
+        "testservice",
+        region_name="us-west-2",
+    )
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(
+            status=200,
+            body=response_payload.encode(),
+            headers=response_headers,
+        )
+        operation_kwargs = {
+            "body": response_payload,
+            "checksumAlgorithm": checksum_algorithm,
+        }
+        if expected["kind"] == "failure":
+            with pytest.raises(FlexibleChecksumError) as expected_error:
+                client.http_checksum_operation(**operation_kwargs)
+            error_msg = "Expected checksum {} did not match calculated checksum: {}".format(
+                response_headers[
+                    f'x-amz-checksum-{checksum_algorithm.lower()}'
+                ],
+                expected['calculatedChecksum'],
+            )
+            assert str(expected_error.value) == error_msg
+        else:
+            client.http_checksum_operation(**operation_kwargs)
+
+
+@pytest.mark.parametrize(
+    "checksum_algorithm, response_payload, response_headers, expected",
+    _response_checksum_validation_cases(),
+)
+def test_streaming_response_checksum_validation(
+    patched_session,
+    monkeypatch,
+    checksum_algorithm,
+    response_payload,
+    response_headers,
+    expected,
+):
+    patch_load_service_model(
+        patched_session,
+        monkeypatch,
+        TEST_CHECKSUM_SERVICE_MODEL,
+        TEST_CHECKSUM_RULESET,
+    )
+    client = patched_session.create_client(
+        "testservice",
+        region_name="us-west-2",
+    )
+    with ClientHTTPStubber(client, strict=True) as http_stubber:
+        http_stubber.add_response(
+            status=200,
+            body=response_payload.encode(),
+            headers=response_headers,
+        )
+        response = client.http_checksum_streaming_operation(
+            body=response_payload,
+            checksumAlgorithm=checksum_algorithm,
+        )
+        if expected["kind"] == "failure":
+            with pytest.raises(FlexibleChecksumError) as expected_error:
+                response["body"].read()
+            error_msg = "Expected checksum {} did not match calculated checksum: {}".format(
+                response_headers[
+                    f'x-amz-checksum-{checksum_algorithm.lower()}'
+                ],
+                expected['calculatedChecksum'],
+            )
+            assert str(expected_error.value) == error_msg
+        else:
+            response["body"].read()

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -17,8 +17,14 @@ from dateutil.tz import tzutc
 
 from botocore.httpchecksum import HAS_CRT, Crc32Checksum, CrtCrc32Checksum
 from tests import (
-    create_session, mock, temporary_file, unittest,
-    BaseSessionTest, ClientHTTPStubber, FreezeTime
+    BaseSessionTest,
+    ClientHTTPStubber,
+    FreezeTime,
+    create_session,
+    get_checksum_cls,
+    mock,
+    temporary_file, unittest,
+
 )
 
 import botocore.session
@@ -3028,7 +3034,7 @@ class TestRequestPayerObjectTagging(BaseS3OperationTest):
 
 class TestS3XMLPayloadEscape(BaseS3OperationTest):
     def assert_correct_crc32_checksum(self, request):
-        checksum = CrtCrc32Checksum() if HAS_CRT else Crc32Checksum()
+        checksum = get_checksum_cls()()
         crc32_checksum = checksum.handle(request.body).encode()
         self.assertEqual(
             crc32_checksum, request.headers["x-amz-checksum-crc32"]

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -15,21 +15,19 @@ import re
 import pytest
 from dateutil.tz import tzutc
 
-from botocore.httpchecksum import HAS_CRT, Crc32Checksum, CrtCrc32Checksum
 from tests import (
     BaseSessionTest,
     ClientHTTPStubber,
     FreezeTime,
     create_session,
-    get_checksum_cls,
     mock,
     temporary_file, unittest,
-
 )
+from tests.utils.botocore import get_checksum_cls
 
 import botocore.session
 from botocore.config import Config
-from botocore.compat import datetime, urlsplit, parse_qs
+from botocore.compat import datetime, parse_qs, urlsplit
 from botocore.exceptions import (
     ParamValidationError, ClientError,
     UnsupportedS3ConfigurationError,
@@ -1411,7 +1409,6 @@ class TestS3SigV4(BaseS3OperationTest):
         )
         body = self.http_stubber.requests[0].body.read()
         self.assertIn(b"x-amz-checksum-crc32", body)
-
 
     def test_trailing_checksum_set_empty_body(self):
         with self.http_stubber:

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -2207,7 +2207,7 @@ class TestCpWithCRTClient(BaseCRTTransferClientTest):
             expected_type=S3RequestType.PUT_OBJECT,
             expected_host=self.get_virtual_s3_host('bucket'),
             expected_path='/key',
-            expected_body_content=b'foo',
+            expected_body_content=b'3\r\nfoo\r\n0\r\nx-amz-checksum-crc32:jHNlIQ==\r\n\r\n',
         )
 
     def test_streaming_download_using_crt_client(self):

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -38,6 +38,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
+                                              'ChecksumMode': 'ENABLED',
                                               'Key': 'mykey'})
 
     def test_range(self):
@@ -48,6 +49,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
+                                              'ChecksumMode': 'ENABLED',
                                               'Key': 'mykey',
                                               'Range': 'bytes=0-499'})
 
@@ -61,7 +63,9 @@ class TestGetObject(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd(
             cmdline, {
-                'Bucket': 'mybucket', 'Key': 'mykey',
+                'Bucket': 'mybucket',
+                'ChecksumMode': 'ENABLED',
+                'Key': 'mykey',
                 'ResponseCacheControl': 'No-cache',
                 'ResponseContentEncoding': 'x-gzip'
             }
@@ -83,7 +87,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd(
-            cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
+            cmdline, {'Bucket': 'mybucket', 'ChecksumMode': 'ENABLED', 'Key': 'mykey'})
 
 
 if __name__ == "__main__":

--- a/tests/unit/botocore/test_httpchecksum.py
+++ b/tests/unit/botocore/test_httpchecksum.py
@@ -14,6 +14,7 @@ import unittest
 from io import BytesIO
 
 from tests import mock
+from tests.utils.botocore import get_checksum_cls, requires_crt
 
 from botocore.awsrequest import AWSResponse
 from botocore.model import OperationModel
@@ -27,14 +28,13 @@ from botocore.httpchecksum import (
     Sha256Checksum,
     CrtCrc64NvmeChecksum,
     Sha1Checksum,
-    CrtCrc32Checksum,
     CrtCrc32cChecksum,
-)
-from botocore.httpchecksum import (
+    CrtCrc32Checksum,
+    CrtCrc64NvmeChecksum,
     apply_request_checksum,
+    handle_checksum_body,
     resolve_request_checksum_algorithm,
     resolve_response_checksum_algorithms,
-    handle_checksum_body,
 )
 
 
@@ -640,6 +640,23 @@ class TestChecksumImplementations(unittest.TestCase):
 
     def test_crt_crc64nvme(self):
         self.assert_base64_checksum(CrtCrc64NvmeChecksum, "jSnVw/bqjr4=")
+
+
+class TestCrtChecksumOverrides(unittest.TestCase):
+    @requires_crt()
+    def test_crt_crc32_available(self):
+        actual_cls = get_checksum_cls("crc32")
+        self.assertEqual(actual_cls, CrtCrc32Checksum)
+
+    @requires_crt()
+    def test_crt_crc32c_available(self):
+        actual_cls = get_checksum_cls("crc32c")
+        self.assertEqual(actual_cls, CrtCrc32cChecksum)
+
+    @requires_crt()
+    def test_crt_crc64nvme_available(self):
+        actual_cls = get_checksum_cls("crc64nvme")
+        self.assertEqual(actual_cls, CrtCrc64NvmeChecksum)
 
 
 class TestStreamingChecksumBody(unittest.TestCase):

--- a/tests/unit/botocore/test_httpchecksum.py
+++ b/tests/unit/botocore/test_httpchecksum.py
@@ -14,7 +14,7 @@ import unittest
 from io import BytesIO
 
 from tests import mock
-from tests.utils.botocore import get_checksum_cls, requires_crt
+from tests.utils.botocore import get_checksum_cls
 
 from botocore.awsrequest import AWSResponse
 from botocore.model import OperationModel
@@ -640,23 +640,6 @@ class TestChecksumImplementations(unittest.TestCase):
 
     def test_crt_crc64nvme(self):
         self.assert_base64_checksum(CrtCrc64NvmeChecksum, "jSnVw/bqjr4=")
-
-
-class TestCrtChecksumOverrides(unittest.TestCase):
-    @requires_crt()
-    def test_crt_crc32_available(self):
-        actual_cls = get_checksum_cls("crc32")
-        self.assertEqual(actual_cls, CrtCrc32Checksum)
-
-    @requires_crt()
-    def test_crt_crc32c_available(self):
-        actual_cls = get_checksum_cls("crc32c")
-        self.assertEqual(actual_cls, CrtCrc32cChecksum)
-
-    @requires_crt()
-    def test_crt_crc64nvme_available(self):
-        actual_cls = get_checksum_cls("crc64nvme")
-        self.assertEqual(actual_cls, CrtCrc64NvmeChecksum)
 
 
 class TestStreamingChecksumBody(unittest.TestCase):

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -39,7 +39,7 @@ from unittest import mock
 import botocore.loaders
 import botocore.session
 from botocore.awsrequest import AWSResponse
-from botocore.compat import HAS_CRT, parse_qs, urlparse
+from botocore.compat import parse_qs, urlparse
 from botocore import utils
 from botocore import credentials
 from botocore.httpchecksum import _CHECKSUM_CLS, DEFAULT_CHECKSUM_ALGORITHM
@@ -82,15 +82,6 @@ def skip_if_windows(reason):
     def decorator(func):
         return unittest.skipIf(
             platform.system() not in ['Darwin', 'Linux'], reason)(func)
-    return decorator
-
-def requires_crt(reason=None):
-    if reason is None:
-        reason = "Test requires awscrt to be installed"
-
-    def decorator(func):
-        return unittest.skipIf(not HAS_CRT, reason)(func)
-
     return decorator
 
 def random_chars(num_chars):

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -84,6 +84,7 @@ def skip_if_windows(reason):
             platform.system() not in ['Darwin', 'Linux'], reason)(func)
     return decorator
 
+
 def random_chars(num_chars):
     """Returns random hex characters.
 

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -39,10 +39,10 @@ from unittest import mock
 import botocore.loaders
 import botocore.session
 from botocore.awsrequest import AWSResponse
-from botocore.compat import urlparse
-from botocore.compat import parse_qs
+from botocore.compat import HAS_CRT, parse_qs, urlparse
 from botocore import utils
 from botocore import credentials
+from botocore.httpchecksum import _CHECKSUM_CLS, DEFAULT_CHECKSUM_ALGORITHM
 from botocore.stub import Stubber
 
 
@@ -84,6 +84,14 @@ def skip_if_windows(reason):
             platform.system() not in ['Darwin', 'Linux'], reason)(func)
     return decorator
 
+def requires_crt(reason=None):
+    if reason is None:
+        reason = "Test requires awscrt to be installed"
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_CRT, reason)(func)
+
+    return decorator
 
 def random_chars(num_chars):
     """Returns random hex characters.
@@ -590,3 +598,13 @@ def patch_load_service_model(
 
     loader = session.get_component('data_loader')
     monkeypatch.setattr(loader, 'load_service_model', mock_load_service_model)
+
+
+def get_checksum_cls(algorithm=DEFAULT_CHECKSUM_ALGORITHM.lower()):
+    """
+    This pass through is grabbing our internally supported list of checksums
+    to ensure we stay in sync, while not exposing them publicly.
+
+    Returns the default checksum algorithm class if none is specified.
+    """
+    return _CHECKSUM_CLS[algorithm]


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/boto/botocore/pull/3277/files#

*Description of changes:*
- Remove MD5 checksums and make CRC32 the default checksum algorithm.
- When the request_checksum_calculation config is set to when_supported (default value), a checksum will be conditionally generated (detailed in source PR)
- When the request_checksum_calculation config is set to when_required, a checksum will be generated conditionally (detailed in source PR):
- Deprecates existing customizations for MD5 checksums.
- A value set for requestValidationModeMember config by the user will be used by the SDK.
- If the requestValidationModeMember value is not set by the user, the requestValidationModeMember will conditionally be set to ENABLED (detailed in source PR)

*Description of tests:*
- Ran and passed all added botocore tests included in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
